### PR TITLE
Support user changing language preference #3

### DIFF
--- a/gabber/api/membership.py
+++ b/gabber/api/membership.py
@@ -121,7 +121,7 @@ class ProjectInvites(Resource):
             db.session.commit()
 
             project = Project.query.get(pid)
-            client = MailClient(user.pref_lang)
+            client = MailClient(user.lang)
             if user.registered or user.verified:
                 client.invite_registered(user, admin.fullname, project)
             else:

--- a/gabber/api/schemas/auth.py
+++ b/gabber/api/schemas/auth.py
@@ -109,9 +109,16 @@ class AuthRegisterSchema(ma.Schema):
 
 
 class UserSchemaHasAccess(ma.ModelSchema):
-    lang = ma.Function(lambda d: SupportedLanguage.query.get(d.pref_lang).id)
-
     class Meta:
         model = User
         include_fk = True
-        exclude = ['connection_comments', 'connections', 'password', 'member_of', 'pref_lang']
+        exclude = ['connection_comments', 'connections', 'password', 'member_of']
+
+    @pre_load()
+    def __validate(self, data):
+        validator = HelperSchemaValidator('auth')
+
+        if data.get('lang', None) and not SupportedLanguage.query.get(data['lang']):
+            validator.errors.append("INVALID_PREFERRED_LANGUAGE")
+
+        validator.raise_if_errors()

--- a/gabber/models/user.py
+++ b/gabber/models/user.py
@@ -49,7 +49,7 @@ class User(db.Model):
     email = db.Column(db.String(64), unique=True)
     password = db.Column(db.String(192))
     fullname = db.Column(db.String(64))
-    pref_lang = db.Column(db.Integer, db.ForeignKey('supported_language.id'))
+    lang = db.Column(db.Integer, db.ForeignKey('supported_language.id'))
 
     # User accounts are created when participating in a session; once registered,
     # this is changed so that we can identify between registers/unregistered users.
@@ -68,7 +68,7 @@ class User(db.Model):
         self.fullname = fullname
         self.email = email
         self.set_password(password)
-        self.pref_lang = preferred_lang
+        self.lang = preferred_lang
         self.registered = registered
 
     @staticmethod


### PR DESCRIPTION
- Renamed `pref_lang` to `lang` as this is the simplified, correct name for it that both the frontend/backend expect

Fixes: #3 